### PR TITLE
Fix for [SONARXML-3] and load external XSDs given an absolute or a relative path

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlSourceCode.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlSourceCode.java
@@ -17,19 +17,19 @@
  */
 package org.sonar.plugins.xml.checks;
 
-import org.apache.commons.io.FileUtils;
-import org.sonar.api.scan.filesystem.ModuleFileSystem;
-import org.sonar.api.utils.SonarException;
-import org.sonar.plugins.xml.parsers.SaxParser;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.utils.SonarException;
+import org.sonar.plugins.xml.parsers.SaxParser;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * Checks and analyzes report measurements, issues and other findings in WebSourceCode.
@@ -85,6 +85,10 @@ public class XmlSourceCode {
 
   private Document parseFile(boolean namespaceAware) {
     return new SaxParser().parseDocument(xmlFile.getFilePath(), createInputStream(), namespaceAware);
+  }
+
+  public File getParentDir() {
+    return xmlFile.getIOFile().getParentFile();
   }
 
   public org.sonar.api.resources.File getSonarFile() {

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/schemas/SchemaResolver.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/schemas/SchemaResolver.java
@@ -17,6 +17,15 @@
  */
 package org.sonar.plugins.xml.schemas;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,18 +36,9 @@ import org.w3c.dom.ls.DOMImplementationLS;
 import org.w3c.dom.ls.LSInput;
 import org.w3c.dom.ls.LSResourceResolver;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Resolves references to XML schema's, if possible built-in.
- * 
+ *
  * @author Matthijs Galesloot
  */
 public final class SchemaResolver implements LSResourceResolver {
@@ -233,6 +233,7 @@ public final class SchemaResolver implements LSResourceResolver {
   /**
    * ResourceResolver tries to resolve schema's and dtd's with built-in resources or external files.
    */
+  @Override
   public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
 
     LOG.debug("Trying to resolve type = {} namespace = {} publicId = {} systemId = {} baseURI = {}", new String[] {type, namespaceURI, publicId, systemId, baseURI});

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/XmlSchemaCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/XmlSchemaCheckTest.java
@@ -17,20 +17,23 @@
  */
 package org.sonar.plugins.xml.checks;
 
-import org.jfree.util.Log;
-import org.junit.Test;
-import org.sonar.api.utils.SonarException;
+import static junit.framework.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 
-import static junit.framework.Assert.assertEquals;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.SonarException;
 
 /**
  * @author Matthijs Galesloot
  */
 public class XmlSchemaCheckTest extends AbstractCheckTester {
+
+  private static final Logger LOG = LoggerFactory.getLogger(XmlSchemaCheckTest.class);
 
   private static final String SRC_TEST_RESOURCES_CHECKS_GENERIC_TENDER_NED_AANKONDIGINGEN_XHTML = "src/test/resources/checks/generic/TenderNed - Aankondigingen.xhtml";
   private static final String SCHEMAS = "schemas";
@@ -70,7 +73,7 @@ public class XmlSchemaCheckTest extends AbstractCheckTester {
     XmlSourceCode sourceCode = parseAndCheck(reader, new File(fileName), null, XmlSchemaCheck.class, SCHEMAS, "autodetect");
 
     if (sourceCode.getXmlIssues().size() > 0) {
-      Log.error(sourceCode.getXmlIssues().get(0).getMessage());
+      LOG.error(sourceCode.getXmlIssues().get(0).getMessage());
     }
     assertEquals(INCORRECT_NUMBER_OF_VIOLATIONS, 0, sourceCode.getXmlIssues().size());
   }
@@ -146,5 +149,16 @@ public class XmlSchemaCheckTest extends AbstractCheckTester {
     XmlSourceCode sourceCode = parseAndCheck(reader, new File(fileName), null, XmlSchemaCheck.class, SCHEMAS, "xhtml1-strict");
 
     assertEquals(INCORRECT_NUMBER_OF_VIOLATIONS, 164, sourceCode.getXmlIssues().size());
+  }
+
+  @Test
+  public void testXsdInclusion() throws FileNotFoundException {
+    String fileName = "src/test/resources/checks/inclusion/b/employee.xml";
+
+    FileReader reader = new FileReader(fileName);
+    XmlSourceCode sourceCode = parseAndCheck(reader, new File(fileName), null, XmlSchemaCheck.class, SCHEMAS,
+        "src/test/resources/checks/inclusion/b/employee.xsd");
+
+    assertEquals(INCORRECT_NUMBER_OF_VIOLATIONS, 0, sourceCode.getXmlIssues().size());
   }
 }

--- a/sonar-xml-plugin/src/test/resources/checks/inclusion/a/person.xsd
+++ b/sonar-xml-plugin/src/test/resources/checks/inclusion/a/person.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:complexType name="personType">
+	<xs:sequence>
+		<xs:element name="firstname" type="xs:string" />
+		<xs:element name="lastname" type="xs:string" />
+	</xs:sequence>
+</xs:complexType>
+</xs:schema>

--- a/sonar-xml-plugin/src/test/resources/checks/inclusion/b/employee.xml
+++ b/sonar-xml-plugin/src/test/resources/checks/inclusion/b/employee.xml
@@ -1,0 +1,6 @@
+<employee
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="employee.xsd">
+	<firstname>John</firstname>
+	<lastname>Doe</lastname>
+</employee>

--- a/sonar-xml-plugin/src/test/resources/checks/inclusion/b/employee.xsd
+++ b/sonar-xml-plugin/src/test/resources/checks/inclusion/b/employee.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:include schemaLocation="../a/person.xsd"/>
+	<xs:element name="employee" type="personType"/>
+</xs:schema>


### PR DESCRIPTION
Typical use case for this feature:
- "employee.xml" references the shema "employee.xsd"
- "employee.xsd" includes "../a/person.xsd"
