### PR TITLE
SONARXML-43: fix for CDATA highlighting issue

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/highlighting/HighlightingData.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/highlighting/HighlightingData.java
@@ -41,4 +41,43 @@ public class HighlightingData {
     return highlightCode;
   }
 
+  
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((endOffset == null) ? 0 : endOffset.hashCode());
+    result = prime * result + ((highlightCode == null) ? 0 : highlightCode.hashCode());
+    result = prime * result + ((startOffset == null) ? 0 : startOffset.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    HighlightingData other = (HighlightingData) obj;
+    if (endOffset == null) {
+      if (other.endOffset != null)
+        return false;
+    } else if (!endOffset.equals(other.endOffset))
+      return false;
+    if (highlightCode == null) {
+      if (other.highlightCode != null)
+        return false;
+    } else if (!highlightCode.equals(other.highlightCode))
+      return false;
+    if (startOffset == null) {
+      if (other.startOffset != null)
+        return false;
+    } else if (!startOffset.equals(other.startOffset))
+      return false;
+    return true;
+  }
+
 }

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/highlighting/XMLHighlighting.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/highlighting/XMLHighlighting.java
@@ -122,13 +122,19 @@ public class XMLHighlighting {
   }
 
   private void highlightCData(int startOffset) {
+	if (!content.substring(startOffset).startsWith("<![CDATA[")) {
+		// Ignoring secondary CDATA event
+		// This has something to do with non-coalescing option of the XML parser
+		return;
+	}
+
     int closingBracketStartOffset = getCDATAClosingBracketStartOffset(startOffset);
 
     // 9 is length of "<![CDATA["
     addHighlighting(startOffset, startOffset + 9, "k");
 
     // highlight "]]>"
-    addHighlighting(closingBracketStartOffset - 2, closingBracketStartOffset + 1, "k");
+    addHighlighting(closingBracketStartOffset - 2, closingBracketStartOffset + 1, "k");	
   }
 
   private void highlightEndElement(XMLStreamReader xmlReader, Location prevLocation, int startOffset) {
@@ -211,10 +217,10 @@ public class XMLHighlighting {
   private int getCDATAClosingBracketStartOffset(int startOffset) {
     return getClosingBracketStartOffset(startOffset, true);
   }
-
+  
   private int getClosingBracketStartOffset(int startOffset, boolean isCDATA) {
     int counter = startOffset + 1;
-    while (startOffset < content.length()) {
+    while (counter < content.length()) {
       if (content.charAt(counter) == '>' && bracketsBefore(isCDATA, counter)) {
         return counter;
       }

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/highlighting/XmlHighlightingTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/highlighting/XmlHighlightingTest.java
@@ -31,7 +31,9 @@ import org.sonar.plugins.xml.language.Xml;
 import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -59,6 +61,24 @@ public class XmlHighlightingTest {
     assertData(highlightingData.get(4), 39, 45, "k");
   }
 
+  
+  @Test
+  public void testCDATAWithJavaCodeInside() throws Exception {
+	String content = "<bpelx:exec xmlns:bpelx=\"http://schemas.oracle.com/bpel/extension\" name=\"SetTitleForDashboard\" version=\"1.5\"\r\n" + 
+    		"                            language=\"java\">\r\n" + 
+    		"                    <![CDATA[String orderId = ((oracle.xml.parser.v2.XMLElement) getVariableData(\"inputVariable\",\"payload\",\"/ns5:StartRatingPlatformOmsAdapterProcessRequest/ns2:OrderId\")).getFirstChild().getNodeValue();         \r\n" + 
+    		"String title = \"RatingPlatformOmsAdapterProcess\" + \" for Order \" + orderId;      \r\n" + 
+    		"setCompositeInstanceTitle(title);]]>\r\n" + 
+    		"                </bpelx:exec>";
+    List<HighlightingData> highlightingDataList = new XMLHighlighting(content).getHighlightingData();
+    
+    Set<HighlightingData> highlightingSet = new HashSet<HighlightingData>(highlightingDataList);
+    assertThat(!highlightingDataList.isEmpty());
+    assertEquals(highlightingSet.size(), highlightingDataList.size());
+  }
+  
+  
+  
   @Test
   public void testCDATAWithBracketInside() throws Exception {
     List<HighlightingData> highlightingData = new XMLHighlighting("<tag><![CDATA[aa]>bb]]></tag>").getHighlightingData();


### PR DESCRIPTION
For some reason (I'm not an expert), the XML parser will deliver two CDATA events in some cases. The workaround is to only create highlight entries for the event generated for the start of the CDATA section.

The resulting plugin version solves the problem on my sonar setup.
`java.lang.IllegalStateException: Cannot register highlighting rule for characters at Range[from [line=189, lineOffset=33] to [line=189, lineOffset=36]])`

This code change replicates the issue with a test case and provides a fix. 

The commit set also contains one fix for a minor bug in org.sonar.plugins.xml.highlighting.XMLHighlighting.getClosingBracketStartOffset(int, boolean) that doesn't seem to cause any harm as long as XML files are valid.


