### PR TITLE
Update SSLR to 1.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,12 +151,16 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
+        <version>19.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
     <gson.version>2.8.0</gson.version>
     <sonar.version>6.2</sonar.version>
-    <sslr.version>1.21</sslr.version>
+    <sslr.version>1.22</sslr.version>
     <sslr-squid-bridge.version>2.6.1</sslr-squid-bridge.version>
     <gitRepositoryName>sonar-xml</gitRepositoryName>
 
@@ -152,6 +152,11 @@
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+     <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>10.0.1</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>

--- a/sonar-xml-plugin/pom.xml
+++ b/sonar-xml-plugin/pom.xml
@@ -50,6 +50,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
Also adds explicit dependency on Guava, because SSLR doesn't depend on
Guava anymore, while this project depends.