### PR TITLE
Added a plugin setting to enable an administrator to define a list of…

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlPlugin.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlPlugin.java
@@ -45,6 +45,12 @@ public final class XmlPlugin implements Plugin {
         .category("XML")
         .onQualifiers(Qualifiers.PROJECT)
         .build(),
+      PropertyDefinition.builder(XmlSensor.FILENAME_LIST_TO_EXCLUDE_FROM_LOC_METRIC_KEY)
+        .name("Filenames to ignore when counting lines of code")
+        .description("Comma-separated list of file name patterns to skip when counting lines of code. You may use regular expressions as long as they don't contain commas. Usage example: You generate an effective-pom.xml file during your scan and want your Sonarqube rules to run against it BUT don't want the line count for that file captured.")
+        .defaultValue("")
+        .category("XML")
+        .build(),
       Xml.class,
       XmlRulesDefinition.class,
       XmlSonarWayProfile.class,

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlPluginTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlPluginTest.java
@@ -33,13 +33,13 @@ public class XmlPluginTest {
   @Test
   public void count_extensions_for_sonarqube_server_6_0() throws Exception {
     Plugin.Context context = setupContext(SonarRuntimeImpl.forSonarQube(Version.create(6, 0), SonarQubeSide.SERVER));
-    assertThat(context.getExtensions()).as("Number of extensions for SQ 6.0").hasSize(5);
+    assertThat(context.getExtensions()).as("Number of extensions for SQ 6.0").hasSize(6);
   }
 
   @Test
   public void count_extensions_for_sonarqube_server_6_2() throws Exception {
     Plugin.Context context = setupContext(SonarRuntimeImpl.forSonarQube(Version.create(6, 2), SonarQubeSide.SERVER));
-    assertThat(context.getExtensions()).as("Number of extensions for SQ 6.2").hasSize(5);
+    assertThat(context.getExtensions()).as("Number of extensions for SQ 6.2").hasSize(6);
   }
 
   private Plugin.Context setupContext(SonarRuntime runtime) {

--- a/sonar-xml-plugin/src/test/resources/xmlsensor/some-configuration-is-code-file.xml
+++ b/sonar-xml-plugin/src/test/resources/xmlsensor/some-configuration-is-code-file.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- could be a Spring, Maven, or other config file. This file is used to validate that lines of code are counted for this kind of XML resource. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>test</name>
+  <build>
+    <sourceDirectory>src/main/code</sourceDirectory>
+  </build> 
+  <properties>
+  	<sonar.xml.sourceDirectory>src</sonar.xml.sourceDirectory>
+  	<sonar.language>xml</sonar.language>
+    <sonar.dynamicAnalysis>false</sonar.dynamicAnalysis>
+    <sonar.xml.fileExtensions>xml</sonar.xml.fileExtensions>
+    <sonar.xml.schemas>xhtml1-strict</sonar.xml.schemas>
+  </properties>
+</project>

--- a/sonar-xml-plugin/src/test/resources/xmlsensor/some-data-file.xml
+++ b/sonar-xml-plugin/src/test/resources/xmlsensor/some-data-file.xml
@@ -1,0 +1,7 @@
+<content>
+  <item-list>
+  	<item>1</item>
+  	<item>2</item>
+  	<item>3</item>
+  </item-list>
+</content>


### PR DESCRIPTION
Added a plugin setting to enable an administrator to define a list of XML file patterns that should not be included in the lines of code metric.

An example case is where we generate an xml report such as "effective-pom.xml" or "classloader-collisions.xml" prior to scanning the project with Sonarqube. In those cases we need Sonar to see the files so that our custom XML rules will raise issues based on their content. They do not represent lines of code for the project though so we need a way to prevent their content from being included in the project's LOC metric. This change provides that capability.