### PR TITLE
Change scope of XmlSourceCode.getDocument(boolean)

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlSourceCode.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/XmlSourceCode.java
@@ -57,7 +57,7 @@ public class XmlSourceCode {
     }
   }
 
-  protected Document getDocument(boolean namespaceAware) {
+  public Document getDocument(boolean namespaceAware) {
     return namespaceAware ? documentNamespaceAware : documentNamespaceUnaware;
   }
 


### PR DESCRIPTION
Changing the scope of this method would allow developpers to extend the sonar-xml-plugin with their custom check in Java, in using <basePlugin>xml</basePlugin> and **without** being in the package org.sonar.plugins.xml.checks.

See this thread for a discussion : [https://groups.google.com/forum/#!topic/sonarqube/A5xyZuHpZO0](https://groups.google.com/forum/#!topic/sonarqube/A5xyZuHpZO0)