### PR TITLE
SONARXML-164 NumberFormatException for "*" in S3417, unable to build dependency from "*:.*log4j"

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/maven/helpers/PatternMatcher.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/maven/helpers/PatternMatcher.java
@@ -37,8 +37,8 @@ public class PatternMatcher implements StringMatcher {
   private static Pattern compileRegex(String regex) {
     try {
       return Pattern.compile(regex, Pattern.DOTALL);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Unable to compile the regular expression: " + regex, e);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Unable to compile the regular expression '"+regex+"', " + e.getMessage());
     }
   }
 

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/maven/helpers/RangedVersionMatcher.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/maven/helpers/RangedVersionMatcher.java
@@ -29,11 +29,19 @@ public class RangedVersionMatcher implements StringMatcher {
   private final ArtifactVersion upperBound;
 
   public RangedVersionMatcher(String lowerBound, String upperBound) {
-    this.lowerBound = isWildCard(lowerBound) ? null : getVersion(lowerBound);
-    this.upperBound = isWildCard(upperBound) ? null : getVersion(upperBound);
+    try {
+      this.lowerBound = isWildCard(lowerBound) ? null : getVersion(lowerBound);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Invalid version range lower bound  '" + lowerBound + "'. " + e.getMessage());
+    }
+    try {
+      this.upperBound = isWildCard(upperBound) ? null : getVersion(upperBound);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Invalid version range upper bound  '" + upperBound + "'. " + e.getMessage());
+    }
     // check that we are not bypassing both bounds
     if ((this.lowerBound == null && this.upperBound == null)) {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("Version range '*-*' is not valid. You should specify at least the lower or the upper bound.");
     }
   }
 
@@ -49,9 +57,9 @@ public class RangedVersionMatcher implements StringMatcher {
   private static ArtifactVersion getVersion(String version) {
     try {
       return ArtifactVersion.parseString(version);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Provided version does not match expected pattern:"
-        + " <major version>.<minor version>.<incremental version> (recieved: " + version + ")", e);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Unsupported version format '" + version + "'. " +
+        "The version does not match expected pattern: '<major version>.<minor version>.<incremental version>'");
     }
   }
 

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/maven/helpers/PatternMatcherTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/maven/helpers/PatternMatcherTest.java
@@ -26,11 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PatternMatcherTest {
 
-  private PatternMatcher matcher;
-
   @Test
   void should_match_patterns() {
-    matcher = new PatternMatcher("[a-z]*");
+    PatternMatcher matcher = new PatternMatcher("[a-z]*");
     assertThat(matcher.test("test")).isTrue();
     assertThat(matcher.test("012")).isFalse();
   }
@@ -39,7 +37,7 @@ class PatternMatcherTest {
   void should_fail_on_invalid_regex() {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
       () -> new PatternMatcher("*"));
-    assertThat(e.getMessage()).isEqualTo("Unable to compile the regular expression: *");
+    assertThat(e.getMessage()).startsWith("Unable to compile the regular expression '*', ");
   }
 
 }

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/maven/helpers/RangedVersionMatcherTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/maven/helpers/RangedVersionMatcherTest.java
@@ -54,7 +54,10 @@ class RangedVersionMatcherTest {
   void fail_with_invalid_version() {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
       () -> new RangedVersionMatcher("1.2.3", "invalid"));
-    assertThat(e.getMessage()).isEqualTo("Provided version does not match expected pattern: <major version>.<minor version>.<incremental version> (recieved: invalid)");
+    assertThat(e.getMessage())
+      .isEqualTo("Invalid version range upper bound  'invalid'." +
+        " Unsupported version format 'invalid'." +
+        " The version does not match expected pattern: '<major version>.<minor version>.<incremental version>'");
   }
 
   @Test


### PR DESCRIPTION
This exception occurred because S3417 was badly configured in SonarQube UI (peach) with the parameter version: `*-2.16.*`
When a version range is used (two versions separated by '-'), the lower or upper bound can be `*` or an exact version `2.16.1`, but not `2.16.*`
When a rule is badly configured, we should log an error explaining what is the error and how to fix it, but not failing the analysis or showing a stack trace.
This PR converts the exception on each analyzed file to a single log ERROR, for the peach misconfiguration it should log one line:
```
[ERROR] The rule xml:S3417 is configured with some invalid parameters.
Invalid Version pattern '*-2.16.*'.
Leave blank for all versions.
You can use '*' as wildcard and '-' as range like '1.0-3.1' or '*-3.1'.
Error: Invalid version range upper bound  '2.16.*'.
Unsupported version format '2.16.*'.
The version does not match expected pattern: '<major version>.<minor version>.<incremental version>'
```