### PR TITLE
SONARXML-174 Update S140 rule metadata

### DIFF
--- a/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.html
+++ b/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.html
@@ -1,3 +1,4 @@
+<h2>Why is this an issue?</h2>
 <p>This rule allows the definition of custom rules using XPath expressions.</p>
 <p>Issues are created depending on the return value of the XPath expression. If the XPath expression returns:</p>
 <ul>
@@ -5,7 +6,7 @@
   <li> a boolean, then a file issue with the given message is created only if the boolean is true </li>
   <li> anything else, no issue is created </li>
 </ul>
-<p>Here is an example of an XPath expression to log an issue on each 'td' tag using the 'nowrap' deprecated attribute: </p>
+<p>Here is an example of an XPath expression to log an issue on each 'td' tag using the 'nowrap' deprecated attribute:</p>
 <pre>
 //td[@nowrap]
 </pre>

--- a/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.json
+++ b/sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.json
@@ -2,10 +2,14 @@
   "title": "Track breaches of an XPath rule",
   "type": "CODE_SMELL",
   "status": "ready",
-  "tags": [
-    
-  ],
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [],
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-140",
-  "sqKey": "XPathCheck"
+  "sqKey": "XPathCheck",
+  "scope": "Main",
+  "quickfix": "unknown"
 }

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "XML"
   ],
-  "latest-update": "2023-05-25T09:20:20.880862542Z",
+  "latest-update": "2023-06-06T13:54:09.458Z",
   "options": {
     "no-language-in-filenames": true
   }


### PR DESCRIPTION
Because the rule has non-numeric key, it is not automatically updated by rule-api.

In order to update the rule, you must first generate the rule metadata and then overwrite the data to have it in the file that matches the non-numeric key.
```
java -jar ../rule-api-2.6.0.2454.jar generate -rule XPathCheck
cp sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S140.html sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.html
cp sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/S140.json sonar-xml-plugin/src/main/resources/org/sonar/l10n/xml/rules/xml/XPathCheck.json
```