### PR TITLE
Change branch guard to enable mend scans on branches named "mend-*"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,8 +72,8 @@ ws_scan_task:
     <<: *CONTAINER_DEFINITION
     cpu: 2
     memory: 2G
-  # run only on master and long-term branches
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
+  # run only on master, long-term branches and mend-related branches
+  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
   maven_cache:


### PR DESCRIPTION
This change allows us to run mend scans in the pipeline without having to comment out the guard and risk leaving it out commented before merging.