### PR TITLE
SONARXML-145 S5332 does not raise when `usesCleartextTraffic` is not explicitly set and minSdk >= 28

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheck.java
@@ -50,7 +50,12 @@ public class AndroidClearTextCheck extends AbstractAndroidManifestCheck {
   protected void scanAndroidManifest(XmlFile file) {
     Document document = file.getDocument();
     evaluateAsList(xPathClearTextTrue, document).forEach(node -> reportAtNameLocation(node, MESSAGE));
-    evaluateAsList(xPathClearTextImplicit, document).forEach(node -> reportAtNameLocation(node, MESSAGE_IMPLICIT));
+    Integer minSdk = getContext().config().getInt("android:minSdkVersion").orElse(27);
+    // As of Android SDK 28, `usesCleartextTraffic` is implicitly set to false by default
+    // See https://developer.android.com/guide/topics/manifest/application-element
+    if (minSdk < 28) {
+      evaluateAsList(xPathClearTextImplicit, document).forEach(node -> reportAtNameLocation(node, MESSAGE_IMPLICIT));
+    }
   }
 
   private void reportAtNameLocation(Node node, String message) {

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.xml.checks.security.android;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonarsource.analyzer.commons.xml.checks.SonarXmlCheckVerifier;
 
 class AndroidClearTextCheckTest {
@@ -32,6 +33,24 @@ class AndroidClearTextCheckTest {
   @Test
   void not_manifest() {
     SonarXmlCheckVerifier.verifyNoIssue("NotManifest.xml", new AndroidClearTextCheck());
+  }
+
+  @Test
+  void does_not_raise_when_usesCleartextTraffic_is_not_set_and_minSdk_greater_or_equal_to_28() {
+    SonarXmlCheckVerifier.verifyNoIssue(
+      "implicit/AndroidManifest.xml",
+      new AndroidClearTextCheck(),
+      new MapSettings().setProperty("android:minSdkVersion", 28)
+    );
+  }
+
+  @Test
+  void raises_when_usesCleartextTraffic_is_not_set_and_minSdk_is_less_than_28() {
+    SonarXmlCheckVerifier.verifyIssues(
+      "implicit/AndroidManifest.xml",
+      new AndroidClearTextCheck(),
+      new MapSettings().setProperty("android:minSdkVersion", 27)
+    );
   }
 
 }

--- a/sonar-xml-plugin/src/test/resources/checks/AndroidClearTextCheck/implicit/AndroidManifest.xml
+++ b/sonar-xml-plugin/src/test/resources/checks/AndroidClearTextCheck/implicit/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.myapp">
+  <!-- Noncompliant@+1 {{"usesCleartextTraffic" is implicitly enabled for older Android versions. Make sure allowing clear-text traffic is safe here.}} -->
+  <application>
+  </application>
+</manifest>


### PR DESCRIPTION
As of version 28 of the Android SDK, the default value of `usesCleartextTraffic` is false[0].

When `minSdk` cannot be found in the project configuration, the assumption is that the project uses an SDK version less than 27.

[0] https://developer.android.com/guide/topics/manifest/application-element