### PR TITLE
[NO-JIRA] Bump analyzer commons to version 2.14.0.3087

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <!-- Minimum version of the plugin API in SQ -->
     <sonar.pluginApi.minVersion>9.14.9.375</sonar.pluginApi.minVersion>
 
-    <sonar.analyzerCommons.version>2.7.0.1482</sonar.analyzerCommons.version>
+    <sonar.analyzerCommons.version>2.14.0.3087</sonar.analyzerCommons.version>
     <sonar.orchestrator.version>5.0.0.2065</sonar.orchestrator.version>
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
     <sonar.sonarlint-core.version>8.17.0.70351</sonar.sonarlint-core.version>


### PR DESCRIPTION
Enable access to context in XML checks.