### PR TITLE
SONARXML-145 Test minimum SDK version based on scanner property

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheck.java
@@ -50,7 +50,7 @@ public class AndroidClearTextCheck extends AbstractAndroidManifestCheck {
   protected void scanAndroidManifest(XmlFile file) {
     Document document = file.getDocument();
     evaluateAsList(xPathClearTextTrue, document).forEach(node -> reportAtNameLocation(node, MESSAGE));
-    Integer minSdk = getContext().config().getInt("android:minSdkVersion").orElse(27);
+    Integer minSdk = getContext().config().getInt("sonar.android.minsdkversion.min").orElse(27);
     // As of Android SDK 28, `usesCleartextTraffic` is implicitly set to false by default
     // See https://developer.android.com/guide/topics/manifest/application-element
     if (minSdk < 28) {

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
@@ -40,7 +40,7 @@ class AndroidClearTextCheckTest {
     SonarXmlCheckVerifier.verifyNoIssue(
       "implicit/AndroidManifest.xml",
       new AndroidClearTextCheck(),
-      new MapSettings().setProperty("android:minSdkVersion", 28)
+      new MapSettings().setProperty("sonar.android.minsdkversion.min", 28)
     );
   }
 
@@ -49,7 +49,7 @@ class AndroidClearTextCheckTest {
     SonarXmlCheckVerifier.verifyIssues(
       "implicit/AndroidManifest.xml",
       new AndroidClearTextCheck(),
-      new MapSettings().setProperty("android:minSdkVersion", 27)
+      new MapSettings().setProperty("sonar.android.minsdkversion.min", 27)
     );
   }
 


### PR DESCRIPTION
As detailed in this ticket[0], and used in S6538, the android version that we should check against is the one defined by the scanners and not the original `android:minSdk` property.

[0] https://sonarsource.atlassian.net/browse/SCANGRADLE-95