### PR TITLE
SONARXML-206 Remove subnet-related config from .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,6 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
     region: eu-central-1
     disk: 128
     type: c5.4xlarge
-    subnet_id: ${CIRRUS_AWS_SUBNET}
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")


### PR DESCRIPTION
[SONARXML-206](https://sonarsource.atlassian.net/browse/SONARXML-206)

cirrus-modules@v3 provides this configuration and it should not be configured in the project itself.




[SONARXML-206]: https://sonarsource.atlassian.net/browse/SONARXML-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ