### PR TITLE
SONARXML-216 Improve cache hits by removing BuildTime and fixing test order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,47 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>de.thetaphi</groupId>
+          <artifactId>forbiddenapis</artifactId>
+          <version>3.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${version.jar.plugin}</version>
+          <configuration>
+            <archive>
+              <addMavenDescriptor>false</addMavenDescriptor>
+              <manifestEntries>
+                <!--
+                  Develocity can reduce the build duration using its cache only for deterministic build.
+                  'Build-Time', defined in the parent pom, changes at each build and prevents us from benefiting from the cache.
+                  We didn't find a solution to unset 'Build-Time', so as a workaround, we provide a constant value '_'.
+                -->
+                <Build-Time>_</Build-Time>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <runOrder>alphabetical</runOrder>
+        </configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
   <profiles>
     <profile>
       <id>its</id>

--- a/pom.xml
+++ b/pom.xml
@@ -182,11 +182,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>de.thetaphi</groupId>
-          <artifactId>forbiddenapis</artifactId>
-          <version>3.6</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${version.jar.plugin}</version>


### PR DESCRIPTION
[SONARXML-216](https://sonarsource.atlassian.net/browse/SONARXML-216)



[SONARXML-216]: https://sonarsource.atlassian.net/browse/SONARXML-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ