### PR TITLE
SONARXML-246 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/xml/XmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/xml/XmlTestSuite.java
@@ -57,6 +57,7 @@ public class XmlTestSuite {
 
   static SonarScanner createSonarScanner() {
     SonarScanner build = SonarScanner.create();
+    build.setProperty("sonar.scanner.skipJreProvisioning", "true");
     // xhtml has been removed from default file suffixes (SONARXML-5)
     build.setProperty("sonar.xml.file.suffixes", ".xml,.xhtml");
     return build;

--- a/its/ruling/src/test/java/org/sonarsource/xml/it/XmlRulingTest.java
+++ b/its/ruling/src/test/java/org/sonarsource/xml/it/XmlRulingTest.java
@@ -95,6 +95,7 @@ class XmlRulingTest {
     ORCHESTRATOR.getServer().associateProjectToQualityProfile("project", LANGUAGE, QUALITY_PROFILE_NAME);
     File litsDifferencesFile = FileLocation.of("target/differences").getFile();
     SonarScanner build = SonarScanner.create(FileLocation.of("../sources/projects").getFile())
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey("project")
       .setProjectName("project")
       .setProjectVersion("1")


### PR DESCRIPTION
[SONARXML-246](https://sonarsource.atlassian.net/browse/SONARXML-246)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.


[SONARXML-246]: https://sonarsource.atlassian.net/browse/SONARXML-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ