### PR TITLE
SONARXML-250 Ignore test fixtures for SCA scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
     <sonar.sonarlint-core.version>8.17.0.70351</sonar.sonarlint-core.version>
     <sonar.pluginApi.version>10.11.0.2468</sonar.pluginApi.version>
+    <sonar.sca.exclusions>its/sources/**,sonar-xml-plugin/src/test/resources/**</sonar.sca.exclusions>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
     <!-- Release: enable publication to Bintray -->


### PR DESCRIPTION
[SONARXML-250](https://sonarsource.atlassian.net/browse/SONARXML-250)



[SONARXML-250]: https://sonarsource.atlassian.net/browse/SONARXML-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ