### PR TITLE
SONARXML-252 Unify Platform Dogfooding of sonar-xml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ env:
   ARTIFACTORY_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
   DEVELOCITY_TOKEN: VAULT[development/kv/data/develocity data.token]
   DEVELOCITY_ACCESS_KEY: develocity.sonar.build=${DEVELOCITY_TOKEN}
+  SONAR_PROJECT_KEY: "org.sonarsource.xml:xml"
   # Use bash (instead of sh on linux or cmd.exe on windows)
   CIRRUS_SHELL: bash
 
@@ -63,6 +64,35 @@ build_task:
     - *log_develocity_url_script
     - source cirrus-env BUILD
     - regular_mvn_build_deploy_analyze
+  cleanup_before_cache_script: cleanup_maven_repository
+
+sonar_shadow_scan_and_issue_replication_task:
+  depends_on:
+    - build
+  # Only run when triggered by the cirrus-ci cron job named "nightly"
+  only_if: $CIRRUS_CRON == "nightly"
+  eks_container:
+    <<: *CONTAINER_DEFINITION
+    cpu: 2
+    memory: 2G
+  env:
+    SHADOW_ORGANIZATION: "sonarsource"
+    SHADOW_PROJECT_KEY: "SonarSource_sonar-xml"
+    # to replicate issue states from next
+    SONAR_TOKEN: VAULT[development/kv/data/next data.token]
+    SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
+    matrix:
+      - name: "sonarcloud.io"
+        SHADOW_SONAR_TOKEN: VAULT[development/kv/data/sonarcloud data.token]
+        SHADOW_SONAR_HOST_URL: "https://sonarcloud.io"
+      - name: "sonarqube.us"
+        SHADOW_SONAR_TOKEN: VAULT[development/kv/data/sonarqube-us data.token]
+        SHADOW_SONAR_HOST_URL: "https://sonarqube.us"
+  maven_cache:
+    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
+  build_script:
+    - *log_develocity_url_script
+    - ./shadow-scan-and-issue-replication.sh
   cleanup_before_cache_script: cleanup_maven_repository
 
 ws_scan_task:
@@ -159,6 +189,7 @@ ruling_win_task:
 promote_task:
   depends_on:
     - build
+    - sonar_shadow_scan_and_issue_replication
     - build_win
     - ruling
     - ruling_win

--- a/shadow-scan-and-issue-replication.sh
+++ b/shadow-scan-and-issue-replication.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# IRIS: Issue Replication for Sonarqube
+IRIS_JAR_URL="${ARTIFACTORY_URL}/sonarsource-private-releases/com/sonarsource/iris/iris/\[RELEASE\]/iris-\[RELEASE\]-jar-with-dependencies.jar"
+IRIS_JAR_PATH="target/libs/iris.jar"
+
+function build_and_analyze_the_project() {
+  echo
+  echo "===== Build and analyze the project targeting a shadow SonarQube instance"
+  mvn \
+    -Pcoverage \
+    -Dmaven.test.redirectTestOutputToFile=false \
+    -Dsonar.host.url="${SHADOW_SONAR_HOST_URL}" \
+    -Dsonar.token="${SHADOW_SONAR_TOKEN}" \
+    -Dsonar.organization="${SHADOW_ORGANIZATION}" \
+    -Dsonar.projectKey="${SHADOW_PROJECT_KEY}" \
+    -Dsonar.analysis.buildNumber="${BUILD_NUMBER}" \
+    -Dsonar.analysis.repository="${GITHUB_REPO}" \
+    --batch-mode --errors --show-version \
+    verify sonar:sonar
+}
+
+function download_iris() {
+  echo
+  echo "===== Download ${IRIS_JAR_URL}"
+  mkdir -p target/libs
+  curl --silent --fail-with-body --location --header "Authorization: Bearer ${ARTIFACTORY_PRIVATE_PASSWORD}" \
+      --output "${IRIS_JAR_PATH}" "${IRIS_JAR_URL}"
+}
+
+function run_iris() {
+  local DRY_RUN="$1"
+  java \
+    -Diris.source.projectKey="${SONAR_PROJECT_KEY}" \
+    -Diris.source.url="${SONAR_HOST_URL}" \
+    -Diris.source.token="${SONAR_TOKEN}" \
+    -Diris.destination.projectKey="${SHADOW_PROJECT_KEY}" \
+    -Diris.destination.organization="${SHADOW_ORGANIZATION}" \
+    -Diris.destination.url="${SHADOW_SONAR_HOST_URL}" \
+    -Diris.destination.token="${SHADOW_SONAR_TOKEN}" \
+    -Diris.dryrun="${DRY_RUN}" \
+    -jar "${IRIS_JAR_PATH}"
+}
+
+function run_iris_with_and_without_dry_run() {
+  echo
+  echo "===== Execute IRIS as dry-run"
+  if run_iris true; then
+    echo "===== Successful IRIS execution as dry-run"
+    echo "===== Execute IRIS for real"
+    if run_iris false; then
+      echo "===== Successful IRIS execution for real"
+      return 0
+    else
+      echo "===== Failed IRIS execution for real"
+      return 1
+    fi
+  else
+    echo "===== Failed IRIS execution as dry-run"
+    return 1
+  fi
+}
+
+source cirrus-env BUILD
+. set_maven_build_version "$BUILD_NUMBER"
+build_and_analyze_the_project
+download_iris
+run_iris_with_and_without_dry_run


### PR DESCRIPTION
[SONARXML-252](https://sonarsource.atlassian.net/browse/SONARXML-252)

A test was done without the `only_if: $CIRRUS_CRON == "nightly"` condition.
The build was: https://cirrus-ci.com/build/5339941422497792

The shadow scan produces the following results:
* https://sonarcloud.io/summary/new_code?id=SonarSource_sonar-xml&pullRequest=348
* https://sonarqube.us/summary/new_code?id=SonarSource_sonar-xml&pullRequest=348

The iris execution logs start here:
* sonarcloud.io: https://cirrus-ci.com/task/5799775330631680?logs=build#L2992
* sonarqube.us: https://cirrus-ci.com/task/5236825377210368?logs=build#L3094


[SONARXML-252]: https://sonarsource.atlassian.net/browse/SONARXML-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ