### PR TITLE
SONARXML-349 Add slf4j-simple to ITs to fix missing orchestrator logs

### DIFF
--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -56,13 +56,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Fixes "Defaulting to no-operation (NOP) logger", which results in missing logs from the orchestrator. -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>
@@ -76,6 +69,13 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Fixes "Defaulting to no-operation (NOP) logger", which results in missing logs from the orchestrator. -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -56,6 +56,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- Fixes "Defaulting to no-operation (NOP) logger", which results in missing logs from the orchestrator. -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -46,6 +46,13 @@
       <version>${sonar.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- Fixes "Defaulting to no-operation (NOP) logger", which results in missing logs from the orchestrator. -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <sonar.sca.exclusions>its/sources/**,sonar-xml-plugin/src/test/resources/**</sonar.sca.exclusions>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
+    <slf4j.version>1.7.36</slf4j.version>
+
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:sonar-xml-plugin:jar</artifactsToPublish>
   </properties>
@@ -103,7 +105,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.36</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.sonarsource.analyzer-commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,10 @@
     <!-- Version required by sonar-orchestrator due to okhttp3.
       If it is not explicit, then we will use the version used by sonarlint-core, which is not compatible. -->
     <kotlin.version>2.2.0</kotlin.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <!-- `its/` are intentionally scanned; only the test project sources are excluded, as we don't have much control over them. -->
     <sonar.sca.exclusions>its/sources/**,sonar-xml-plugin/src/test/resources/**</sonar.sca.exclusions>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-
-    <slf4j.version>1.7.36</slf4j.version>
 
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:sonar-xml-plugin:jar</artifactsToPublish>


### PR DESCRIPTION
## Summary
- Add `slf4j-simple` as a test dependency in `its/plugin` and `its/ruling` to fix the "Defaulting to no-operation (NOP) logger" warning, which causes missing logs from the orchestrator
- Extract the SLF4J version (`1.7.36`) into a `<slf4j.version>` property in the root POM

Mirrors https://github.com/SonarSource/sonar-java/commit/002e057a4d5baa3ac8be1e7fc6137684cc40dee6

🤖 Generated with [Claude Code](https://claude.com/claude-code)