### PR TITLE
SONARXML-345 Use github-ubuntu-latest-s in cleanup-cache.yml

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: sonar-xs-public
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
We cannot use sonar-*-public, because the repo is not whitelisted. When we try to run the workflow, it waits for a runner forever.

Test: https://github.com/SonarSource/sonar-xml/actions/runs/24668823551 - it fails, so I guess we need to run it after we merge, but at least the job started