### PR TITLE
SONARXML-370 Bump orchestrator and sonarlint-core versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <sonar.pluginApi.minVersion>9.14.9.375</sonar.pluginApi.minVersion>
 
     <sonar.analyzerCommons.version>2.20.0.4607</sonar.analyzerCommons.version>
-    <sonar.orchestrator.version>6.1.0.3962</sonar.orchestrator.version>
+    <sonar.orchestrator.version>6.2.0.4392</sonar.orchestrator.version>
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
-    <sonar.sonarlint-core.version>11.3.0.85510</sonar.sonarlint-core.version>
+    <sonar.sonarlint-core.version>11.4.0.85676</sonar.sonarlint-core.version>
     <sonar.pluginApi.version>13.2.0.3137</sonar.pluginApi.version>
     <!-- Version required by sonar-orchestrator due to okhttp3.
       If it is not explicit, then we will use the version used by sonarlint-core, which is not compatible. -->


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `sonar.orchestrator.version` to `6.2.0.4392` in `pom.xml`.
  - Bumped `sonar.sonarlint-core.version` to `11.4.0.85676` in `pom.xml`.

<sub>This will update automatically on new commits.</sub>