### PR TITLE
CLP-71 Upgrade gh-action_release to @v7 for SonarXML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,13 @@
 ---
 name: sonar-release
-# This workflow is triggered when publishing a new github release
+# This workflow is triggered by automated-release.yml
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       version:
         type: string
         description: Version
-        required: true
-      releaseId:
-        type: string
-        description: Release ID
         required: true
       dryRun:
         type: boolean
@@ -26,11 +19,10 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: squad-jvm-notifs
-      version: ${{ inputs.version || github.event.release.tag_name }}
-      releaseId: ${{ inputs.releaseId || github.event.release.id }}
+      version: ${{ inputs.version }}
       dryRun: ${{ inputs.dryRun == true }}


### PR DESCRIPTION
Part of CLP-26

----
## Summary by Gitar

- **CI/CD Workflow updates:**
  - Upgraded `gh-action_release` to `@v7` in `.github/workflows/release.yml`.
  - Modified workflow trigger to use `workflow_dispatch` instead of `release: published`.
  - Removed `releaseId` input and simplified `version` input handling.

<sub>This will update automatically on new commits.</sub>