### PR TITLE
CLP-86 Update notifications Slack channels

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: core-languages-releases
+          slack-channel: squad-corelang-releases

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: squad-jvm-notifs
+          slack-channel: core-languages-releases

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -65,7 +65,7 @@ jobs:
       create-slvscode-ticket: ${{ github.event.inputs.ide-integration == 'true' }}
       branch: ${{ github.event.inputs.branch }}
       pm-email: "jean.jimbo@sonarsource.com"
-      slack-channel: "core-languages-releases"
+      slack-channel: "squad-corelang-releases"
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -65,7 +65,7 @@ jobs:
       create-slvscode-ticket: ${{ github.event.inputs.ide-integration == 'true' }}
       branch: ${{ github.event.inputs.branch }}
       pm-email: "jean.jimbo@sonarsource.com"
-      slack-channel: "squad-jvm-releases"
+      slack-channel: "core-languages-releases"
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
     with:
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: squad-jvm-notifs
+      slackChannel: squad-corelang-releases
       version: ${{ inputs.version }}
       dryRun: ${{ inputs.dryRun == true }}

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
-          slackChannel: squad-jvm-notifs
+          slackChannel: squad-core-notifs

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
-          slackChannel: squad-core-notifs
+          slackChannel: squad-corelang-notifs


### PR DESCRIPTION
Part of [CLP-59](https://sonarsource.atlassian.net/browse/CLP-59).

[CLP-59]: https://sonarsource.atlassian.net/browse/CLP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **CI/CD configuration:**
  - Updated Slack notification channels from `squad-jvm-*` to `squad-corelang-releases` in `ToggleLockBranch.yml`, `automated-release.yml`, and `release.yml`.
  - Redirected `slack_notify.yml` notifications to `squad-corelang-notifs`.

<sub>This will update automatically on new commits.</sub>