### PR TITLE
SONARXML-306 Use squad Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:sonar-xml"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "enabledManagers": [
     "maven",

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>SonarSource/renovate-config:languages-team",
+    "local>SonarSource/core-languages-tooling-public:renovate-config",
     ":timezone(CET)",
     ":semanticCommitsDisabled"
+  ],
+  "addLabels": [
+    "dependencies"
   ],
   "schedule": [
     "before 3am on Monday"
   ],
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "maven",
     "github-actions",
@@ -19,6 +24,20 @@
   ],
   "dependencyDashboard": true,
   "packageRules": [
+    {
+      "matchManagers": [
+        "regex"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"
+    },
+    {
+      "description": "Group Maven updates",
+      "matchManagers": [
+        "maven"
+      ],
+      "groupName": "Maven dependencies",
+      "groupSlug": "maven-dependencies"
+    },
     {
       "matchPackagePatterns": ["^org.sonarsource.xml:", "^org.sonarsource.sonarqube:"],
       "enabled": false
@@ -88,6 +107,16 @@
         "org.sonarsource.sonarlint.core.*"
       ],
       "groupName": "SL core"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^snapshot-generation.sh$"
+      ],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\sexport .*?_VERSION=(?<currentValue>.*)\\s"
+      ]
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:renovate-config",
-    ":timezone(CET)",
-    ":semanticCommitsDisabled"
+    "local>SonarSource/core-languages-tooling-public:sonar-xml"
   ],
-  "addLabels": [
-    "dependencies"
-  ],
-  "schedule": [
-    "before 3am on Monday"
-  ],
-  "rebaseWhen": "conflicted",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "maven",
     "github-actions",
@@ -22,24 +12,12 @@
     "its/sources/**",
     "sonar-xml-plugin/src/test/resources/**"
   ],
-  "dependencyDashboard": true,
   "packageRules": [
     {
-      "matchManagers": [
-        "regex"
+      "matchPackagePatterns": [
+        "^org.sonarsource.xml:",
+        "^org.sonarsource.sonarqube:"
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"
-    },
-    {
-      "description": "Group Maven updates",
-      "matchManagers": [
-        "maven"
-      ],
-      "groupName": "Maven dependencies",
-      "groupSlug": "maven-dependencies"
-    },
-    {
-      "matchPackagePatterns": ["^org.sonarsource.xml:", "^org.sonarsource.sonarqube:"],
       "enabled": false
     },
     {
@@ -50,7 +28,10 @@
         "SonarSource/*"
       ],
       "pinDigests": false,
-      "labels": ["dependencies", "github-actions"],
+      "labels": [
+        "dependencies",
+        "github-actions"
+      ],
       "groupName": "all Sonar GitHub Actions",
       "groupSlug": "all-sonar-github-actions"
     },
@@ -62,7 +43,10 @@
         "!SonarSource/*"
       ],
       "pinDigests": true,
-      "labels": ["dependencies", "github-actions"],
+      "labels": [
+        "dependencies",
+        "github-actions"
+      ],
       "groupName": "all third-party GitHub Actions",
       "groupSlug": "all-3rd-party-github-actions"
     },
@@ -70,19 +54,31 @@
       "matchManagers": [
         "maven"
       ],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "stabilityDays": 3,
       "automerge": false,
-      "labels": ["dependencies", "maven", "major-update"]
+      "labels": [
+        "dependencies",
+        "maven",
+        "major-update"
+      ]
     },
     {
       "matchManagers": [
         "maven"
       ],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "dependencyDashboardApproval": true,
       "automerge": false,
-      "labels": ["dependencies", "maven"],
+      "labels": [
+        "dependencies",
+        "maven"
+      ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     },
@@ -108,24 +104,5 @@
       ],
       "groupName": "SL core"
     }
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": [
-        "^snapshot-generation.sh$"
-      ],
-      "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\sexport .*?_VERSION=(?<currentValue>.*)\\s"
-      ]
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": [
-      "vulnerability-alert"
-    ]
-  },
-  "reviewers": [
-    "team:quality-jvm-squad"
   ]
 }


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- rebaseWhen: conflicted -> never
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- schedule: before 3am on Monday -> unset
- prCreation: not-pending -> immediate
- semanticCommits: disabled -> unset
- reviewers: team:quality-jvm-squad -> unset
- vulnerabilityAlerts: {"enabled":true,"labels":["vulnerability-alert"]} -> unset
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}
- packageRules added: Don't group updates by default
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
