### PR TITLE
APPSEC-3488 S2068: use substring matching for credential words

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
@@ -71,6 +71,7 @@ public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
     if (cleanedCredentialWords == null) {
       cleanedCredentialWords = Stream.of(credentialWords.split(","))
         .map(String::trim)
+        .filter(word -> !word.isEmpty())
         .map(word -> word.toLowerCase(Locale.ROOT))
         .collect(Collectors.toSet());
     }
@@ -105,7 +106,12 @@ public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
   private void checkNode(Node node) {
     NodeList childNodes = node.getChildNodes();
     if (childNodes.getLength() == 0) {
-      checkAttributes(node, VALUE_ATTRIBUTE, false);
+      if (node.hasAttributes()) {
+        Node valueAttr = node.getAttributes().getNamedItem(VALUE);
+        if (valueAttr != null) {
+          checkCredential(node, valueAttr.getTextContent());
+        }
+      }
       return;
     }
     if (childNodes.getLength() != 1) {
@@ -137,7 +143,8 @@ public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
     if (localName == null) {
       return false;
     }
-    return credentialWords.contains(localName.toLowerCase(Locale.ROOT)) &&
+    String lowerName = localName.toLowerCase(Locale.ROOT);
+    return credentialWords.stream().anyMatch(lowerName::contains) &&
       !"android:password".equalsIgnoreCase(node.getNodeName());
   }
 
@@ -167,7 +174,7 @@ public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
         .map(Node::getNodeValue)
         .map(String::toLowerCase);
 
-    boolean keyIsCredentialWord = keyValueLowerCase.map(credentialWordsSet()::contains).orElse(false);
+    boolean keyIsCredentialWord = keyValueLowerCase.map(key -> credentialWordsSet().stream().anyMatch(key::contains)).orElse(false);
     Node valueNode = attributes.getNamedItem(VALUE);
     return keyIsCredentialWord && valueNode != null && !isValidCredential(valueNode.getNodeValue());
   }
@@ -185,13 +192,6 @@ public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
     new SpecialCase(
       "/FileZilla3/Servers/Server/Pass"
         + "|/FileZilla3/RecentServers/Server/Pass",
-      HardcodedCredentialsCheck::getTextValueSafe,
-      false),
-    // Jenkins
-    new SpecialCase(
-      "/jenkins.plugins.publish_over_ssh.BapSshHostConfiguration/secretPassword"
-        + "|/jenkins.plugins.publish_over_ssh.BapSshHostConfiguration/commonConfig/secretPassphrase"
-        + "|/jenkins.plugins.publish_over_ssh.BapSshHostConfiguration/keyInfo/secretPassphrase",
       HardcodedCredentialsCheck::getTextValueSafe,
       false),
     // SonarQube

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheckTest.java
@@ -43,6 +43,13 @@ class HardcodedCredentialsCheckTest {
     SonarXmlCheckVerifier.verifyIssues("customized.xml", check);
   }
 
+  @Test
+  void empty_credential_word_tokens_are_ignored() {
+    HardcodedCredentialsCheck check = new HardcodedCredentialsCheck();
+    check.credentialWords = "password,,pwd";
+    SonarXmlCheckVerifier.verifyNoIssue("empty_credential_word.xml", check);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {
     "dbeaver-data-sources.xml",

--- a/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/app-settings/web.config
+++ b/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/app-settings/web.config
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <appSettings>
-        <add key="Password" value="thisisbad" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
+        <add key="Password" value="Kd83Vm719" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
 <!--    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
         <add key="color" value="blue" />
-        <add key="password" value="thisisbadtoo" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
+        <add key="password" value="Kd83Vm719Xy2" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
 <!--    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
         <add key="password" />
         <add key="password" value="" />  <!-- Should not raise -->
@@ -14,6 +14,8 @@
         <remove key="Password" />  <!-- Should not raise -->
         <add key="passwd" value="other word" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
 <!--    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
+        <add key="dbPassword" value="Kd83Vm719Xy2" /> <!-- Noncompliant {{Review the hard-coded credential, which may be sensitive.}} -->
+<!--    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
         <clear />
         <remove key="Password" />
     </appSettings>

--- a/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/empty_credential_word.xml
+++ b/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/empty_credential_word.xml
@@ -1,0 +1,3 @@
+<config>
+  <color>Kd83Vm719</color>
+</config>

--- a/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/tagsAndProperties.xml
+++ b/sonar-xml-plugin/src/test/resources/checks/HardcodedCredentialsCheck/tagsAndProperties.xml
@@ -9,6 +9,10 @@
         <!-- ^^^^^^^^^^^^^^^ -->
       <x:PASSWORD value="Kd83Vm719" /> <!-- Noncompliant {{"PASSWORD" detected here, make sure this is not a hard-coded credential.}} -->
  <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
+      <dbPassword>Kd83Vm719</dbPassword> <!-- Noncompliant {{"dbPassword" detected here, make sure this is not a hard-coded credential.}} -->
+ <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -->
+      <myTag dbPassword="Kd83Vm719"> </myTag> <!-- Noncompliant {{"dbPassword" detected here, make sure this is not a hard-coded credential.}} -->
+        <!-- ^^^^^^^^^^^^^^^^^^^^^^ -->
     </noncompliant>
 
     <compliant>
@@ -25,6 +29,8 @@
       <password>arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/db-AbCdEf</password>
       <password><nonText /></password>
       <password encryption="SSH" />
+      <!-- Compliant: 'defaultvalue' contains 'value' as substring but should not be matched as credential attribute -->
+      <password defaultvalue="Kd83Vm719" />
       <password>
         <child1></child1>
         <child2></child2>


### PR DESCRIPTION
## Summary

- `isCredentialNode` and `isAddWithPassword` previously used exact set membership (`Set.contains`) to match node/attribute names against credential words (e.g. `password`). This meant `dbPassword` would not raise an issue.
- sonar-iac and sonar-go both use `find`-based substring matching, so a key named `dbPassword` containing the word `password` triggers the rule. This PR aligns sonar-xml with that behavior.
- The Jenkins `BapSshHostConfiguration` special case (`secretPassword`, `secretPassphrase`) was removed — it was added precisely because the full-match generic check missed those names. Substring matching in the generic check now covers them, making the special case redundant (and its presence caused double-reporting).

## Test plan

- [ ] All 223 existing tests pass (`mvn test -pl sonar-xml-plugin`)
- [ ] New noncompliant test cases added for `<dbPassword>` as element name, attribute, and `<add key="dbPassword" .../>` in appSettings

Closes APPSEC-3488