### PR TITLE
SONARXML-401 Fix quality gate

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
@@ -17,7 +17,6 @@
 package org.sonar.plugins.xml.checks.security;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/security/HardcodedCredentialsCheck.java
@@ -43,7 +43,6 @@ import org.w3c.dom.NodeList;
 public class HardcodedCredentialsCheck extends SimpleXPathBasedCheck {
 
   private static final String VALUE = "value";
-  private static final Set<String> VALUE_ATTRIBUTE = Collections.singleton(VALUE);
 
   private static final XPathExpression WEB_CONFIG_CREDENTIALS_PATH = XPathBuilder
     .forExpression("/configuration/system.web/authentication[@mode=\"Forms\"]/forms/credentials[@passwordFormat=\"Clear\"]/user/@password[string-length(.) > 0]").build();


### PR DESCRIPTION
----
## Summary by Gitar

- **Code cleanup:**
  - Removed unused private field in `HardcodedCredentialsCheck` to satisfy quality gate requirements.

<sub>This will update automatically on new commits.</sub>