### PR TITLE
SONARXML-404 Replace plugin-api-impl dependency with sensor-test-fixtures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
     <sonar.sonarlint-core.version>11.6.0.85952</sonar.sonarlint-core.version>
     <sonar.pluginApi.version>13.8.0.4399</sonar.pluginApi.version>
+    <sonar.scanner.version>13.4.0.3968</sonar.scanner.version>
     <!-- Version required by sonar-orchestrator due to okhttp3.
       If it is not explicit, then we will use the version used by sonarlint-core, which is not compatible. -->
     <kotlin.version>2.4.0</kotlin.version>
@@ -133,9 +134,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.sonarqube</groupId>
-        <artifactId>sonar-plugin-api-impl</artifactId>
-        <version>${sonar.version}</version>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>sensor-test-fixtures</artifactId>
+        <version>${sonar.scanner.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/sonar-xml-plugin/pom.xml
+++ b/sonar-xml-plugin/pom.xml
@@ -95,8 +95,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Part of [SONARXML-380](https://sonarsource.atlassian.net/browse/SONARXML-380).

[SONARXML-380]: https://sonarsource.atlassian.net/browse/SONARXML-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Dependency Management:**
  - Replaced `sonar-plugin-api-impl` with `sensor-test-fixtures` in both parent and `sonar-xml-plugin` POM files.
  - Added `sonar.scanner.version` property `13.4.0.3968` to support the new test dependency.

<sub>This will update automatically on new commits.</sub>