### PR TITLE
SONARXML-411 Add ability to register rules in built-in profiles from other plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,9 @@ jobs:
           SQ_VERSION: ${{ matrix.item.sq_version }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
         run: |
+          if [ $SUITE = "plugin" ]; then
+            mvn install -f test-plugin/pom.xml
+          fi;
           mvn verify "-Pit-${SUITE}" "-Dsonar.runtimeVersion=${SQ_VERSION}" -Dmaven.test.redirectTestOutputToFile=false -B -e -V
 
   promote:

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>it-xml-plugin</artifactId>
-
   <name>SonarSource XML Analyzer :: IT Plugin</name>
   <inceptionYear>2013</inceptionYear>
 

--- a/its/plugin/src/test/java/com/sonar/it/xml/ProfileRegistrarTest.java
+++ b/its/plugin/src/test/java/com/sonar/it/xml/ProfileRegistrarTest.java
@@ -1,0 +1,103 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package com.sonar.it.xml;
+
+import com.sonar.orchestrator.container.Edition;
+import com.sonar.orchestrator.junit5.OrchestratorExtension;
+import com.sonar.orchestrator.locator.FileLocation;
+import com.sonar.orchestrator.locator.Location;
+import com.sonar.orchestrator.locator.MavenLocation;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarqube.ws.client.HttpConnector;
+import org.sonarqube.ws.client.WsClient;
+import org.sonarqube.ws.client.WsClientFactories;
+
+import static com.sonar.it.xml.XmlTestSuite.DEFAULT_SQ_VERSION;
+import static com.sonar.it.xml.XmlTestSuite.SQ_VERSION_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileRegistrarTest {
+
+  @RegisterExtension
+  static final OrchestratorExtension ORCHESTRATOR = OrchestratorExtension.builderEnv()
+    .useDefaultAdminCredentialsForBuilds(true)
+    .setEdition(Edition.ENTERPRISE_LW)
+    .setSonarVersion(System.getProperty(SQ_VERSION_PROPERTY, DEFAULT_SQ_VERSION))
+    .addPlugin(FileLocation.byWildcardMavenFilename(new File("../../sonar-xml-plugin/target"), "sonar-xml-plugin-*.jar"))
+    .addPlugin(getTestPlugin())
+    .restoreProfileAtStartup(FileLocation.ofClasspath("/sonar-way-it-profile_xml.xml"))
+    .restoreProfileAtStartup(FileLocation.ofClasspath("/empty-profile.xml"))
+    .build();
+
+  private static Location getTestPlugin() {
+    // Always use the test plugin that was built on local machine
+    String projectVersion = System.getProperty("projectVersion");
+    return MavenLocation.of("org.sonarsource.xml", "test-plugin", projectVersion);
+  }
+
+  private static WsClient newWsClient() {
+    return WsClientFactories.getDefault().newClient(HttpConnector.newBuilder()
+      .url(ORCHESTRATOR.getServer().getUrl())
+      .build());
+  }
+
+  @Test
+  void testPluginRegistersRuleInDefaultXmlProfile() {
+    var wsClient = newWsClient();
+
+    // First, query the quality profiles to find the profile key for Xml's "Sonar way" profile
+    var profileSearchRequest = new org.sonarqube.ws.client.qualityprofiles.SearchRequest()
+      .setLanguage("xml");
+
+    var profileResponse = wsClient.qualityprofiles().search(profileSearchRequest);
+
+    var xmlProfile = profileResponse.getProfilesList().stream()
+      .filter(profile -> "Sonar way".equals(profile.getName()) && profile.getIsBuiltIn())
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Built-in 'Sonar way' profile not found for xml language"));
+
+    var profileKey = xmlProfile.getKey();
+
+    // Query the active rules in the built-in "Sonar way" profile for xml language using the profile key
+    var rulesSearchRequest = new org.sonarqube.ws.client.rules.SearchRequest()
+      .setLanguages(List.of("xml"))
+      .setQprofile(profileKey)
+      .setActivation("true");
+
+    var rulesResponse = wsClient.rules().search(rulesSearchRequest);
+
+    // Verify that the profile contains the TEST001 rule from xml-test repository
+    // This rule is registered by the TestProfileRegistrar in the test-plugin
+    var testRules = rulesResponse.getRulesList().stream()
+      .filter(rule -> "xml-test:TEST001".equals(rule.getKey()))
+      .toList();
+
+    assertThat(testRules)
+      .as("Rule xml-test:TEST001 should be registered in the default xml profile by TestProfileRegistrar")
+      .hasSize(1);
+
+    var testRule = testRules.get(0);
+    assertThat(testRule.getKey()).isEqualTo("xml-test:TEST001");
+    assertThat(testRule.getRepo()).isEqualTo("xml-test");
+  }
+
+}

--- a/its/plugin/src/test/java/com/sonar/it/xml/XmlTestSuite.java
+++ b/its/plugin/src/test/java/com/sonar/it/xml/XmlTestSuite.java
@@ -41,11 +41,12 @@ import static java.util.Collections.singletonList;
   RequiredForLanguagesTest.class,
   ByteOrderMarkTest.class,
   XmlTest.class,
-  SonarLintIntegrationTest.class})
+  SonarLintIntegrationTest.class,
+  ProfileRegistrarTest.class})
 public class XmlTestSuite {
 
-  private static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
-  private static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
+  protected static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
+  protected static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
 
   @RegisterExtension
   static final OrchestratorExtension ORCHESTRATOR = OrchestratorExtension.builderEnv()

--- a/its/plugin/test-plugin/pom.xml
+++ b/its/plugin/test-plugin/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonarsource.xml</groupId>
+        <artifactId>xml-its</artifactId>
+        <version>2.19.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-plugin</artifactId>
+    <packaging>sonar-plugin</packaging>
+
+    <properties>
+        <sonar.skip>true</sonar.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonarsource.xml</groupId>
+            <artifactId>sonar-xml-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+      <plugins>
+         <plugin>
+         <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
+         <artifactId>sonar-packaging-maven-plugin</artifactId>
+         <configuration>
+           <pluginName>Minimalistic test plugin</pluginName>
+           <pluginClass>org.sonarsource.xml.TestPlugin</pluginClass>
+           <skipDependenciesPackaging>true</skipDependenciesPackaging>
+           <sonarLintSupported>true</sonarLintSupported>
+           <pluginApiMinVersion>${sonar.pluginApi.minVersion}</pluginApiMinVersion>
+           <requiredForLanguages>xml</requiredForLanguages>
+         </configuration>
+        </plugin>
+      </plugins>
+    </build>
+
+</project>

--- a/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestPlugin.java
+++ b/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.xml;
+
+import org.sonar.api.Plugin;
+
+/**
+ * Minimalistic SonarQube plugin for testing purposes.
+ */
+public class TestPlugin implements Plugin {
+
+  @Override
+  public void define(Context context) {
+    // Register the rules definition that defines the TEST001 rule
+    context.addExtension(TestRulesDefinition.class);
+    // Register the profile registrar that adds the rule to the default Xml quality profile
+    context.addExtension(TestProfileRegistrar.class);
+  }
+}

--- a/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestProfileRegistrar.java
+++ b/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestProfileRegistrar.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.xml;
+
+import java.util.List;
+
+import org.sonar.api.rule.RuleKey;
+import org.sonar.plugins.xml.api.XmlProfileRegistrar;
+
+/**
+ * Test implementation of XmlProfileRegistrar that adds a single rule to the default quality profile.
+ */
+public class TestProfileRegistrar implements XmlProfileRegistrar {
+
+  @Override
+  public void register(RegistrarContext registrarContext) {
+    RuleKey ruleKey = RuleKey.of(TestRulesDefinition.REPOSITORY_KEY, TestRulesDefinition.RULE_KEY);
+    registrarContext.registerDefaultQualityProfileRules(List.of(ruleKey));
+  }
+}

--- a/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestRulesDefinition.java
+++ b/its/plugin/test-plugin/src/main/java/org/sonarsource/xml/TestRulesDefinition.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.xml;
+
+import org.sonar.api.server.rule.RulesDefinition;
+
+/**
+ * Defines a test rule repository with a single TEST001 rule.
+ */
+public class TestRulesDefinition implements RulesDefinition {
+
+  static final String REPOSITORY_KEY = "xml-test";
+  static final String LANGUAGE_KEY = "xml";
+  private static final String REPOSITORY_NAME = "Test Xml Rules";
+  static final String RULE_KEY = "TEST001";
+
+  @Override
+  public void define(Context context) {
+    NewRepository repository = context.createRepository(REPOSITORY_KEY, LANGUAGE_KEY)
+      .setName(REPOSITORY_NAME);
+
+    // Define the TEST001 rule
+    repository.createRule(RULE_KEY)
+      .setName("Test Rule 001")
+      .setHtmlDescription("This is a test rule for integration testing purposes.");
+
+    repository.done();
+  }
+}

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -13,6 +13,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>plugin/test-plugin</module>
     <module>plugin</module>
     <module>ruling</module>
   </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <runOrder>alphabetical</runOrder>
+          <systemPropertyVariables>
+            <projectVersion>${project.version}</projectVersion>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlSonarWayProfile.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/XmlSonarWayProfile.java
@@ -16,15 +16,33 @@
  */
 package org.sonar.plugins.xml;
 
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
+import org.sonar.plugins.xml.api.XmlProfileRegistrar;
 import org.sonarsource.analyzer.commons.BuiltInQualityProfileJsonLoader;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class XmlSonarWayProfile implements BuiltInQualityProfilesDefinition {
+
+  private final List<RuleKey> additionalRules = new ArrayList<>();
+
+  public XmlSonarWayProfile() {
+    this(new XmlProfileRegistrar[] {});
+  }
+
+  public XmlSonarWayProfile(XmlProfileRegistrar[] xmlProfileRegistrars) {
+    for (XmlProfileRegistrar xmlProfileRegistrar : xmlProfileRegistrars) {
+      xmlProfileRegistrar.register(additionalRules::addAll);
+    }
+  }
 
   @Override
   public void define(Context context) {
     NewBuiltInQualityProfile sonarWay = context.createBuiltInQualityProfile(Xml.SONAR_WAY_PROFILE_NAME, Xml.KEY);
     BuiltInQualityProfileJsonLoader.load(sonarWay, Xml.REPOSITORY_KEY, Xml.SONAR_WAY_PATH);
+    additionalRules.forEach(ruleKey -> sonarWay.activateRule(ruleKey.repository(), ruleKey.rule()));
     sonarWay.done();
   }
 

--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/api/XmlProfileRegistrar.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/api/XmlProfileRegistrar.java
@@ -1,0 +1,53 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.xml.api;
+
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.server.ServerSide;
+
+import java.util.Collection;
+
+/**
+ * This class can be extended to provide additional rule keys in the builtin default quality profile.
+ *
+ * <pre>
+ *   {@code
+ *     public void register(RegistrarContext registrarContext) {
+ *       registrarContext.registerDefaultQualityProfileRules(ruleKeys);
+ *     }
+ *   }
+ * </pre>
+ *
+ */
+@ServerSide
+public interface XmlProfileRegistrar {
+
+  /**
+   * This method is called on server side and during an analysis to modify the builtin default quality profile for Xml.
+   */
+  void register(RegistrarContext registrarContext);
+
+  interface RegistrarContext {
+    /**
+     * Registers additional rules into the "Sonar Way" default quality profile for Xml.
+     *
+     * @param ruleKeys additional rule keys
+     */
+    void registerDefaultQualityProfileRules(Collection<RuleKey> ruleKeys);
+  }
+
+}

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSonarWayProfileTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSonarWayProfileTest.java
@@ -17,29 +17,55 @@
 package org.sonar.plugins.xml;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 import org.sonar.api.utils.ValidationMessages;
+import org.sonar.plugins.xml.api.XmlProfileRegistrar;
 import org.sonar.plugins.xml.checks.CheckList;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class XmlSonarWayProfileTest {
 
-  @Test
-  void should_create_sonar_way_profile() {
-    ValidationMessages validation = ValidationMessages.create();
+    @Test
+    void should_create_sonar_way_profile() {
+        ValidationMessages validation = ValidationMessages.create();
 
-    BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
+        BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
 
-    XmlSonarWayProfile definition = new XmlSonarWayProfile();
-    definition.define(context);
+        XmlSonarWayProfile definition = new XmlSonarWayProfile();
+        definition.define(context);
 
-    BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile(Xml.KEY, Xml.SONAR_WAY_PROFILE_NAME);
+        BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile(Xml.KEY, Xml.SONAR_WAY_PROFILE_NAME);
 
-    assertThat(profile.language()).isEqualTo(Xml.KEY);
-    assertThat(profile.name()).isEqualTo(Xml.SONAR_WAY_PROFILE_NAME);
-    assertThat(profile.rules()).hasSizeGreaterThan(10);
-    assertThat(profile.rules()).hasSizeLessThan(CheckList.getCheckClasses().size());
-    assertThat(validation.hasErrors()).isFalse();
-  }
+        assertThat(profile.language()).isEqualTo(Xml.KEY);
+        assertThat(profile.name()).isEqualTo(Xml.SONAR_WAY_PROFILE_NAME);
+        assertThat(profile.rules()).hasSizeGreaterThan(10);
+        assertThat(profile.rules()).hasSizeLessThan(CheckList.getCheckClasses().size());
+        assertThat(validation.hasErrors()).isFalse();
+    }
+
+    @Test
+    void profileWithRegistrarAddingAdditionalRules() {
+        // Create a test registrar that adds custom rules to the built-in profile
+        XmlProfileRegistrar testRegistrar = registrarContext -> {
+            RuleKey customRule1 = RuleKey.of("custom-repo", "CUSTOM001");
+            RuleKey customRule2 = RuleKey.of("another-repo", "ANOTHER001");
+            registrarContext.registerDefaultQualityProfileRules(List.of(customRule1, customRule2));
+        };
+
+        // Create profile definition with the registrar
+        BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
+        new XmlSonarWayProfile(new XmlProfileRegistrar[]{testRegistrar}).define(context);
+        BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile("xml", "Sonar way");
+
+        // Verify that the profile contains both default rules and additional rules from registrar
+        assertThat(profile.rules()).hasSizeGreaterThan(2);
+        assertThat(profile.rules()).extracting("repoKey").contains("xml", "custom-repo", "another-repo");
+        assertThat(profile.rules()).extracting(BuiltInQualityProfilesDefinition.BuiltInActiveRule::ruleKey)
+                .contains("S1135", "CUSTOM001", "ANOTHER001");
+    }
+
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **New API:**
  - Introduced `XmlProfileRegistrar` interface allowing external plugins to register additional rules into the built-in XML quality profile.
- **Implementation:**
  - Modified `XmlSonarWayProfile` to collect and activate rule keys provided by registered `XmlProfileRegistrar` extensions.
- **Testing:**
  - Added integration tests in `ProfileRegistrarTest` and created a `test-plugin` to verify cross-plugin rule registration.

<sub>This will update automatically on new commits.</sub>