### PR TITLE
SONARXML-412 Add package-info for org.sonar.plugins.xml.api

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/api/package-info.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/api/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * SonarQube XML Plugin
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package org.sonar.plugins.xml.api;


### PR DESCRIPTION
----
## Summary by Gitar

- **API Documentation:**
  - Added `package-info.java` to `org.sonar.plugins.xml.api` to declare package-level annotations.
  - Applied `@ParametersAreNonnullByDefault` to ensure null-safety for the API package.

<sub>This will update automatically on new commits.</sub>