### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <!-- Minimum version of the plugin API in SQ -->
     <sonar.pluginApi.minVersion>9.14.9.375</sonar.pluginApi.minVersion>
 
-    <sonar.analyzerCommons.version>2.27.0.5007</sonar.analyzerCommons.version>
+    <sonar.analyzerCommons.version>2.28.0.5070</sonar.analyzerCommons.version>
     <sonar.orchestrator.version>6.3.0.4464</sonar.orchestrator.version>
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
     <sonar.sonarlint-core.version>11.6.0.85952</sonar.sonarlint-core.version>
@@ -131,6 +131,12 @@
         <groupId>org.sonarsource.sonarlint.core</groupId>
         <artifactId>sonarlint-core</artifactId>
         <version>${sonar.sonarlint-core.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>plugin-api-scanner-impl</artifactId>
+        <version>${sonar.scanner.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <!-- Minimum version of the plugin API in SQ -->
     <sonar.pluginApi.minVersion>9.14.9.375</sonar.pluginApi.minVersion>
 
-    <sonar.analyzerCommons.version>2.28.0.5070</sonar.analyzerCommons.version>
+    <sonar.analyzerCommons.version>2.28.0.5085</sonar.analyzerCommons.version>
     <sonar.orchestrator.version>6.3.0.4464</sonar.orchestrator.version>
     <!-- Minimum SL version supporting ${sonar.pluginApi.minVersion} -->
     <sonar.sonarlint-core.version>11.6.0.85952</sonar.sonarlint-core.version>

--- a/sonar-xml-plugin/pom.xml
+++ b/sonar-xml-plugin/pom.xml
@@ -96,6 +96,11 @@
     </dependency>
     <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
       <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
@@ -389,4 +394,3 @@
   </profiles>
 
 </project>
-

--- a/sonar-xml-plugin/pom.xml
+++ b/sonar-xml-plugin/pom.xml
@@ -182,7 +182,7 @@
               <rules>
                 <requireFilesSize>
                   <maxsize>2750000</maxsize>
-                  <minsize>2650000</minsize>
+                  <minsize>2400000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/LineCounterTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/LineCounterTest.java
@@ -17,6 +17,8 @@
 package org.sonar.plugins.xml;
 
 import com.google.gson.Gson;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -24,8 +26,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonarsource.analyzer.commons.xml.ParseException;
 import org.sonarsource.analyzer.commons.xml.XmlFile;

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlHighlightingTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlHighlightingTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.BufferedWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -26,11 +29,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -41,7 +42,7 @@ class XmlHighlightingTest {
   @TempDir
   public Path tmpFolder;
 
-  private DefaultFileSystem fileSystem;
+  private TestFileSystem fileSystem;
   private SensorContextTester context;
   private XmlFile xmlFile;
 
@@ -326,9 +327,8 @@ class XmlHighlightingTest {
     Path moduleBaseDir = Files.createTempDirectory(tmpFolder, "");
     context = SensorContextTester.create(moduleBaseDir);
 
-    fileSystem = new DefaultFileSystem(moduleBaseDir);
-    fileSystem.setEncoding(fileSystemCharset);
-    context.setFileSystem(fileSystem);
+    context.setFileSystem(new DefaultFileSystem(moduleBaseDir));
+    fileSystem = context.fileSystem().setEncoding(fileSystemCharset);
 
     String filename = "utf16.xml";
     Path file = moduleBaseDir.resolve(filename);

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlPluginTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlPluginTest.java
@@ -16,11 +16,11 @@
  */
 package org.sonar.plugins.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ class XmlPluginTest {
   @SuppressWarnings("unchecked")
   @Test
   void count_extensions() {
-    Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
+    Plugin.Context context = new Plugin.Context(TestSonarRuntime.forSonarQube(Version.create(7, 9), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
     new XmlPlugin().define(context);
     assertThat(context.getExtensions()).as("Number of extensions for SQ 7.9").hasSize(5);
   }

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlRulesDefinitionTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlRulesDefinitionTest.java
@@ -16,16 +16,16 @@
  */
 package org.sonar.plugins.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Rule;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.xml.checks.CheckList;
 
@@ -58,7 +58,7 @@ class XmlRulesDefinitionTest {
 
   @Test
   void test() {
-    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(SonarRuntimeImpl.forSonarLint(Version.create(9, 6)));
+    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(TestSonarRuntime.forSonarLint(Version.create(9, 6)));
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
     RulesDefinition.Repository repository = context.repository("xml");
@@ -92,7 +92,7 @@ class XmlRulesDefinitionTest {
 
   @Test
   void test_security_standards() {
-    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(SonarRuntimeImpl.forSonarLint(Version.create(9, 6)));
+    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(TestSonarRuntime.forSonarLint(Version.create(9, 6)));
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
     RulesDefinition.Repository repository = context.repository("xml");
@@ -104,7 +104,7 @@ class XmlRulesDefinitionTest {
 
   @Test
   void test_security_standards_before_sq_9_3() {
-    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(SonarRuntimeImpl.forSonarLint(Version.create(9, 2)));
+    XmlRulesDefinition rulesDefinition = new XmlRulesDefinition(TestSonarRuntime.forSonarLint(Version.create(9, 2)));
     RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
     RulesDefinition.Repository repository = context.repository("xml");

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSensorTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSensorTest.java
@@ -381,8 +381,7 @@ class XmlSensorTest {
       .build();
     CheckFactory checkFactory = new CheckFactory(activeRules);
 
-    FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
-    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
+    FileLinesContextFactory fileLinesContextFactory = mockFileLinesContextFactory();
 
     sensor = new XmlSensor(SQ_LTS_RUNTIME, fs, checkFactory, fileLinesContextFactory);
   }
@@ -405,8 +404,7 @@ class XmlSensorTest {
 
     CheckFactory checkFactory = new CheckFactory(activeRuleBuilder.build());
 
-    FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
-    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
+    FileLinesContextFactory fileLinesContextFactory = mockFileLinesContextFactory();
 
     sensor = new XmlSensor(sonarRuntime, fs, checkFactory, fileLinesContextFactory);
   }
@@ -435,13 +433,19 @@ class XmlSensorTest {
       .build();
     CheckFactory checkFactory = new CheckFactory(activeRules);
 
-    FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
-    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
+    FileLinesContextFactory fileLinesContextFactory = mockFileLinesContextFactory();
     sensor = new XmlSensor(SQ_LTS_RUNTIME, fileSystem, checkFactory, fileLinesContextFactory);
     sensor.execute(context);
 
     String componentKey = "modulekey:" + filename;
     assertThat(context.measure(componentKey, CoreMetrics.NCLOC).value()).isEqualTo(2);
+  }
+
+  private static FileLinesContextFactory mockFileLinesContextFactory() {
+    FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
+    FileLinesContext fileLinesContext = mock(FileLinesContext.class);
+    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(fileLinesContext);
+    return fileLinesContextFactory;
   }
 
   private void assertLog(String expected, boolean isRegexp) {

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSensorTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlSensorTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,23 +41,13 @@ import org.slf4j.event.Level;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.FileMetadata;
-import org.sonar.api.batch.fs.internal.Metadata;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
-import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
-import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -62,6 +55,13 @@ import org.sonar.api.rule.RuleKey;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
 import org.sonar.plugins.xml.checks.TabCharacterCheck;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
+import org.sonar.scanner.plugin.api.impl.fs.FileMetadata;
+import org.sonar.scanner.plugin.api.impl.fs.Metadata;
+import org.sonar.scanner.plugin.api.impl.rule.ActiveRulesBuilder;
+import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 import org.sonarsource.analyzer.commons.xml.checks.SonarXmlCheck;
 
@@ -88,7 +88,7 @@ class XmlSensorTest {
   private static final RuleKey PARSING_ERROR_RULE_KEY = RuleKey.of(Xml.REPOSITORY_KEY, PARSING_ERROR_CHECK_KEY);
   private static final RuleKey TAB_CHARACTER_RULE_KEY = RuleKey.of(Xml.REPOSITORY_KEY, TabCharacterCheck.RULE_KEY);
   private static final RuleKey HARDCODED_CREDENTIALS_RULE_KEY = RuleKey.of(Xml.REPOSITORY_KEY, "S2068");
-  public static final SonarRuntime SQ_LTS_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
+  public static final SonarRuntime SQ_LTS_RUNTIME = TestSonarRuntime.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
 
   @Test
   @Timeout(value = 12000, unit = TimeUnit.MILLISECONDS)
@@ -148,7 +148,7 @@ class XmlSensorTest {
 
   @Test
   void test_descriptor_sonarlint() throws Exception {
-    init(SonarRuntimeImpl.forSonarLint(Version.create(6, 5)), false);
+    init(TestSonarRuntime.forSonarLint(Version.create(6, 5)), false);
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
     sensor.describe(sensorDescriptor);
     assertThat(sensorDescriptor.name()).isEqualTo("XML Sensor");
@@ -157,7 +157,7 @@ class XmlSensorTest {
 
   @Test
   void test_descriptor_sonarqube_9_3() throws Exception {
-    init(SonarRuntimeImpl.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY), false);
+    init(TestSonarRuntime.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY), false);
     final boolean[] called = {false};
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor() {
       @Override
@@ -174,7 +174,7 @@ class XmlSensorTest {
 
   @Test
   void test_descriptor_sonarqube_9_3_reflection_failure() throws Exception {
-    init(SonarRuntimeImpl.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY), false);
+    init(TestSonarRuntime.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY), false);
     DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor() {
       @Override
       public SensorDescriptor processesFilesIndependently() {
@@ -235,7 +235,7 @@ class XmlSensorTest {
     DefaultInputFile inputFile = createInputFile("src/pom.xml");
     fs.add(inputFile);
 
-    context.setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(4, 1)));
+    context.setRuntime(TestSonarRuntime.forSonarLint(Version.create(4, 1)));
     sensor.execute(context);
 
     assertThat(context.allIssues()).extracting("ruleKey").containsOnly(NEW_LINE_RULE_KEY);

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/XmlTest.java
@@ -18,7 +18,7 @@ package org.sonar.plugins.xml;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidApplicationBackupCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidApplicationBackupCheckTest.java
@@ -17,7 +17,7 @@
 package org.sonar.plugins.xml.checks.security.android;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 import org.sonarsource.analyzer.commons.xml.checks.SonarXmlCheckVerifier;
 
 class AndroidApplicationBackupCheckTest {

--- a/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
+++ b/sonar-xml-plugin/src/test/java/org/sonar/plugins/xml/checks/security/android/AndroidClearTextCheckTest.java
@@ -17,7 +17,7 @@
 package org.sonar.plugins.xml.checks.security.android;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 import org.sonarsource.analyzer.commons.xml.checks.SonarXmlCheckVerifier;
 
 class AndroidClearTextCheckTest {


### PR DESCRIPTION
## Summary

- upgrade Analyzer Commons to the promoted `2.28.0.5070` artifact from its scanner-fixture migration
- migrate moved scanner implementation imports and replace `SonarRuntimeImpl` with `TestSonarRuntime`
- declare scanner-engine test dependencies directly where their concrete types are imported

## Dependency changes

Before: XML tests and Analyzer Commons `2.27` used `org.sonarsource.sonarqube:sonar-plugin-api-impl` and the old `org.sonar.api.*.internal` packages.

After: tests use `plugin-api-scanner-impl` and `sensor-test-fixtures` at `13.4.1.4007`, together with Analyzer Commons `2.28.0.5070`. The resolved Maven graph contains no `sonar-plugin-api-impl`.

`sonar-plugin-api-test-fixtures` is retained specifically for `LogTesterJUnit5`.

## Validation

- `mvn -q test -pl sonar-xml-plugin -am`
- Maven dependency-tree check for `org.sonarsource.sonarqube:sonar-plugin-api-impl` (no matches)
- legacy-import search and `git diff --check`
