### PR TITLE
SONARXML-419 Fix QG: Update collect method to use ToList()

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/CommentedOutCodeCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/CommentedOutCodeCheck.java
@@ -77,7 +77,7 @@ public class CommentedOutCodeCheck extends SimpleXPathBasedCheck {
   private List<Node> getComments(XmlFile file) {
     return evaluateAsList(commentsExpression, file.getDocument()).stream()
       .filter(comment -> comment.getTextContent().trim().startsWith("<"))
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private static List<Node> getNextCommentSiblings(Node comment) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Code Refactoring:**
    - Updated `CommentedOutCodeCheck` to use `Stream.toList()` for collecting comment nodes instead of `Collectors.toList()`.

<sub>This will update automatically on new commits.</sub>