### PR TITLE
SONARXML-420 Use Stream.toList() for comments

### DIFF
--- a/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/CommentedOutCodeCheck.java
+++ b/sonar-xml-plugin/src/main/java/org/sonar/plugins/xml/checks/CommentedOutCodeCheck.java
@@ -77,7 +77,7 @@ public class CommentedOutCodeCheck extends SimpleXPathBasedCheck {
   private List<Node> getComments(XmlFile file) {
     return evaluateAsList(commentsExpression, file.getDocument()).stream()
       .filter(comment -> comment.getTextContent().trim().startsWith("<"))
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private static List<Node> getNextCommentSiblings(Node comment) {


### PR DESCRIPTION
Part of

## Summary

- replace `Collectors.toList()` with `Stream.toList()` for filtered comments
- resolve the `java:S6204` issue failing the Quality Gate

## Testing

- `mvn -pl sonar-xml-plugin -Dtest=CommentedOutCodeCheckTest test`