### PR TITLE
SONARXML-446 Remove redundant logging dependency handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,6 @@
     <!-- Version required by sonar-orchestrator due to okhttp3.
       If it is not explicit, then we will use the version used by sonarlint-core, which is not compatible. -->
     <kotlin.version>2.4.10</kotlin.version>
-    <!-- The product must work with the SLF4J provided in the Plugin API. -->
-    <slf4j.version>2.0.18</slf4j.version>
     <!-- `its/` are intentionally scanned; only the test project sources are excluded, as we don't have much control over them. -->
     <sonar.sca.exclusions>its/sources/**,sonar-xml-plugin/src/test/resources/**</sonar.sca.exclusions>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -102,11 +100,6 @@
         <groupId>org.sonarsource.api.plugin</groupId>
         <artifactId>sonar-plugin-api-test-fixtures</artifactId>
         <version>${sonar.pluginApi.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.sonarsource.analyzer-commons</groupId>

--- a/sonar-xml-plugin/pom.xml
+++ b/sonar-xml-plugin/pom.xml
@@ -42,12 +42,6 @@
       </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
Part of

## Summary

- Remove redundant SLF4J and Logback dependency declarations, constraints, and update exceptions.
- Rely on Sonar Plugin API v14 and its test fixtures to provide SLF4J 2.0.18 and Logback 1.6.3.

